### PR TITLE
Add update layer to containers

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -12,6 +12,8 @@ ENV NODE_ENV=production
 # PhantomJS is broken on alpine and crashes CodiMD
 ENV CMD_ALLOW_PDF_EXPORT=false
 
+RUN apk upgrade --no-cache
+
 RUN apk add --no-cache --virtual .download wget  ca-certificates && \
     wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
     tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -9,6 +9,12 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV DOCKERIZE_VERSION v0.6.1
 ENV NODE_ENV=production
 
+RUN true \
+    && apt-get update \
+    && apt-get upgrade -y \
+    && apt-get clean && apt-get purge && rm -r /var/lib/apt/lists/* \
+    && true
+
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
     tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
     rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz


### PR DESCRIPTION
Since base images are not kept up-to-date by Docker Inc. all the time,
it is our own duty to update the packages inside the base images.

This patch provides an update layer for Alpine and Debian. This should
help to get rid of some detected vulnerabilities.