### PR TITLE
Reverse proxy with Minio docker-compose example

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,21 @@ services:
       backend:
     restart: always
 
+  # Minio will be used as S3 Provider for image uploads
+  imagestore:
+    image: minio/minio:RELEASE.2019-05-02T19-07-09Z
+    restart: always
+    volumes:
+      - minio:/data
+    environment:
+      - MINIO_ACCESS_KEY=randomCodiMDKey
+      - MINIO_SECRET_KEY=randomCodiMDSecret
+    # Normally this requires to manually create a bucket
+    # but with the command it will automatically create a bucket
+    command: -c 'mkdir -p /data/codimd && minio server /codimd'
+    networks:
+      backend:
+
   # MySQL example
   # Most of the documentation that applies to PostgreSQL applies also to MySQL
   #database:
@@ -69,26 +84,67 @@ services:
       # - sqlite:///data/sqlite.db (NOT RECOMMENDED)
       # - For details see the official sequelize docs: http://docs.sequelizejs.com/en/v3/
       - CMD_DB_URL=postgres://hackmd:hackmdpass@database:5432/hackmd
-    ports:
+      # Minio S3 Configuration
+      - CMD_IMAGE_UPLOAD_TYPE=minio
+      - CMD_S3_BUCKET=codimd
+      - CMD_MINIO_ACCESS_KEY=randomCodiMDKey
+      - CMD_MINIO_SECRET_KEY=randomCodiMDSecret
+      - CMD_MINIO_ENDPOINT=imagestore
+      - CMD_MINIO_PORT=9000
+      - CMD_MINIO_SECURE=false
+    labels:
+      # This should be the external domain you want to use for CodiMD
+      - traefik.frontend.rule=Host:codimd.example.org
+      - traefik.port=3000
+      - traefik.docker.network=web
+    # Alternatively if you don't want to use the traefik reverse proxy you can publish
+    # CodiMD directly with a port as explained below
+    #ports:
       # Ports that are published to the outside.
       # The latter port is the port inside the container. It should always stay on 3000
       # If you only specify a port it'll published on all interfaces. If you want to use a
       # local reverse proxy, you may want to listen on 127.0.0.1.
       # Example:
       # - "127.0.0.1:3000:3000"
-      - "3000:3000"
+      #- "3000:3000"
     networks:
       backend:
+      web:
     restart: always
     depends_on:
       - database
+      - imagestore
+  reverseproxy:
+  # traefik is used as reverse proxy for CodiMD
+  # It automatically listens on docker for exposed services
+  # in the web network
+    image: traefik:2.0-alpine
+    restart: always
+    networks:
+      - web
+    ports:
+      # These ports should be exported to the network.
+      # By default HTTPS will use self-signed certificates
+      # but with some extra configuration traefik can automatically request
+      # Let's Encrypt certificates:
+      # https://docs.traefik.io/configuration/acme/
+      # Example:
+      # - "127.0.0.1:80:80"
+      - 80:80
+      - 443:443
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
 
 # Define networks to allow best isolation
 networks:
   # Internal network for communication with PostgreSQL/MySQL
   backend:
+  # Network that includes components that will be exported
+  web:
 
 # Define named volumes so data stays in place
 volumes:
   # Volume for PostgreSQL/MySQL database
-  database:
+  database: {}
+  minio: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,11 +32,23 @@ services:
     environment:
       - MINIO_ACCESS_KEY=randomCodiMDKey
       - MINIO_SECRET_KEY=randomCodiMDSecret
+    #mem_limit: 256mb         # version 2 only
+    #memswap_limit: 512mb     # version 2 only
+    #read_only: true          # not supported in swarm mode please enable along with tmpfs
+    #tmpfs:
+    #  - /run/minio:size=512K
+    #  - /tmp:size=256K
     # Normally this requires to manually create a bucket
     # but with the command it will automatically create a bucket
-    command: -c 'mkdir -p /data/codimd && minio server /codimd'
+    command: -c 'mkdir -p /data/codimd && minio server /data'
     networks:
       backend:
+      web:
+    labels:
+       # This should be the external domain you want to use for Minio
+      - traefik.frontend.rule=Host:minio.example.org
+      - traefik.port=9000
+      - traefik.docker.network=web  
 
   # MySQL example
   # Most of the documentation that applies to PostgreSQL applies also to MySQL
@@ -118,7 +130,7 @@ services:
   # traefik is used as reverse proxy for CodiMD
   # It automatically listens on docker for exposed services
   # in the web network
-    image: traefik:2.0-alpine
+    image: traefik:1.7-alpine
     restart: always
     networks:
       - web

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,6 +105,11 @@ services:
       - CMD_MINIO_ENDPOINT=imagestore
       - CMD_MINIO_PORT=9000
       - CMD_MINIO_SECURE=false
+      - CMD_URL_ADDPORT=false
+      - CMD_PROTOCOL_USESSL=true
+      # This domain name should be the same as the one exported to traefik below
+      - CMD_DOMAIN=codimd.example.org
+      
     labels:
       # This should be the external domain you want to use for CodiMD
       - treafik.enabled=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
       web:
     labels:
        # This should be the external domain you want to use for Minio
+      - treafik.enabled=true
       - traefik.frontend.rule=Host:minio.example.org
       - traefik.port=9000
       - traefik.docker.network=web  
@@ -106,6 +107,7 @@ services:
       - CMD_MINIO_SECURE=false
     labels:
       # This should be the external domain you want to use for CodiMD
+      - treafik.enabled=true
       - traefik.frontend.rule=Host:codimd.example.org
       - traefik.port=3000
       - traefik.docker.network=web
@@ -134,6 +136,15 @@ services:
     restart: always
     networks:
       - web
+    # It is required to replace the email placeholder here for
+    # Let's Encrypt to work
+    command: >
+      "-c /dev/null --docker "
+      "--acme --acme.email=###email-address### "
+      "--acme.storage=/etc/traefik/acme/acme.json --acme.onhostrule "
+      "--entryPoints='Name:http Address::80 Redirect.EntryPoint:https' "
+      "--entryPoints='Name:https Address::443 Compress:true TLS' "
+      "--defaultentrypoints=http,https --docker.exposedbydefault=false"
     ports:
       # These ports should be exported to the network.
       # By default HTTPS will use self-signed certificates
@@ -146,6 +157,7 @@ services:
       - 443:443
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - acme:/etc/traefik/acme
 
 
 # Define networks to allow best isolation
@@ -160,3 +172,4 @@ volumes:
   # Volume for PostgreSQL/MySQL database
   database: {}
   minio: {}
+  acme: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,13 +144,13 @@ services:
     #  - /tmp:size=256K
     # It is required to replace the email placeholder here for
     # Let's Encrypt to work
-    command: >
-      "-c /dev/null --docker "
-      "--acme --acme.email=###email-address### "
-      "--acme.storage=/etc/traefik/acme/acme.json --acme.onhostrule "
-      "--entryPoints='Name:http Address::80 Redirect.EntryPoint:https' "
-      "--entryPoints='Name:https Address::443 Compress:true TLS' "
-      "--defaultentrypoints=http,https --docker.exposedbydefault=false"
+    command: >-
+      -c /dev/null --docker 
+      --acme --acme.email=###email-address### 
+      --acme.storage=/etc/traefik/acme/acme.json --acme.onhostrule 
+      --entryPoints='Name:http Address::80 Redirect.EntryPoint:https' 
+      --entryPoints='Name:https Address::443 Compress:true TLS' 
+      --defaultentrypoints=http,https --docker.exposedbydefault=false
     ports:
       # These ports should be exported to the network.
       # By default HTTPS will use self-signed certificates

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,6 +136,12 @@ services:
     restart: always
     networks:
       - web
+    #mem_limit: 256mb         # version 2 only
+    #memswap_limit: 512mb     # version 2 only
+    #read_only: true          # not supported in swarm mode please enable along with tmpfs
+    #tmpfs:
+    #  - /run/traefik:size=512K
+    #  - /tmp:size=256K
     # It is required to replace the email placeholder here for
     # Let's Encrypt to work
     command: >


### PR DESCRIPTION
For traefiks Let's Encrypt support additional changes need to be made to the written configuration of traefik. I didn't include those