### PR TITLE
DB URL: Secret File Support

### DIFF
--- a/resources/docker-entrypoint.sh
+++ b/resources/docker-entrypoint.sh
@@ -12,7 +12,9 @@ if [ "$HMD_IMAGE_UPLOAD_TYPE" != "" ] && [ "$CMD_IMAGE_UPLOAD_TYPE" = "" ]; then
     CMD_IMAGE_UPLOAD_TYPE="$HMD_IMAGE_UPLOAD_TYPE"
 fi
 
-if [ "$CMD_DB_URL" = "" ]; then
+if [ "$CMD_DB_URL_FILE" != "" ]; then
+    CMD_DB_URL=`cat "$CMD_DB_URL_FILE"`
+elif [ "$CMD_DB_URL" = "" ]; then
     CMD_DB_URL="postgres://hackmd:hackmdpass@hackmdPostgres:5432/hackmd"
 fi
 


### PR DESCRIPTION
Adds a possibility to read the db URL from a file, that could e.g. be provided by a Docker secret, following https://github.com/codimd/server/pull/128.